### PR TITLE
Debug/ai service/pika queue

### DIFF
--- a/ai_service/consumer.py
+++ b/ai_service/consumer.py
@@ -1,0 +1,27 @@
+# Setup consumer for RabbitMQ side
+#
+
+import pika
+import os
+
+def on_message_received(ch, method, properties, body):
+    print(f"received new prompt: {body}")
+
+# Set connection parameters
+rmq_url = os.getenv('RABBITMQ_URL')
+connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
+channel = connection.channel()
+
+# Note(Lani): it's ok that we declare the queue twice (ie in here and producer)
+# Declare the queue from user to RabbitMQ
+channel.queue_declare(queue='poem_requests')
+# Declare the queue from RabbitMQ to user
+channel.queue_declare(queue='poem_responses')
+
+# Setup consume parameters
+channel.basic_consume(queue='poem_requests', auto_ack=True,
+    on_message_callback=on_message_received)
+
+print("Starting Consuming")
+# Start consumption
+channel.start_consuming()

--- a/ai_service/main.py
+++ b/ai_service/main.py
@@ -1,119 +1,119 @@
-# Copyright 2024 Robert Cronin
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# # Copyright 2024 Robert Cronin
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     https://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 
-import pika
-import json
-import os
-import random
-import base64
-from datetime import datetime, timezone
-from dotenv import load_dotenv
-from openai import OpenAI
-from ratelimit import limits, sleep_and_retry
+# import pika
+# import json
+# import os
+# import random
+# import base64
+# from datetime import datetime, timezone
+# from dotenv import load_dotenv
+# from openai import OpenAI
+# from ratelimit import limits, sleep_and_retry
 
-load_dotenv()
+# load_dotenv()
 
-# RabbitMQ connection
-rmq_url = os.getenv('RABBITMQ_URL')
-connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
-channel = connection.channel()
+# # RabbitMQ connection
+# rmq_url = os.getenv('RABBITMQ_URL')
+# connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
+# channel = connection.channel()
 
-# Declare the queues
-channel.queue_declare(queue='poem_requests')
-channel.queue_declare(queue='poem_responses')
+# # Declare the queues
+# channel.queue_declare(queue='poem_requests')
+# channel.queue_declare(queue='poem_responses')
 
-# OpenAI setup
-client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+# # OpenAI setup
+# client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
 
-# Rate limiting: 50 messages per hour
-
-
-@sleep_and_retry
-@limits(calls=50, period=3600)
-def generate_poem(prompt):
-    response = client.completions.create(
-        model="gpt-3.5-turbo-instruct",
-        prompt=f"Create a Chinese 绝句 (jué jù) poem based on the following prompt: {prompt}",
-        max_tokens=100,
-        n=1,
-        stop=None,
-        temperature=0.7
-    )
-    return response.choices[0].text.strip()
+# # Rate limiting: 50 messages per hour
 
 
-def callback(ch, method, properties, body):
-    # Decode the Base64 encoded message
-    decoded_body = base64.b64decode(body).decode('utf-8')
-    message = json.loads(decoded_body)
-
-    poem_request_id = message['id']
-    user_id = message['user_id']
-    prompt = message['prompt']
-    created_at = message['created_at']
-
-    try:
-        poem = generate_poem(prompt)
-
-        response = {
-            'id': poem_request_id,
-            'user_id': user_id,
-            'prompt': prompt,
-            'poem': poem,
-            'status': 'completed',
-            'created_at': created_at,
-            'updated_at': datetime.now(timezone.utc).isoformat()
-        }
-
-        # Publish the response
-        channel.basic_publish(
-            exchange='',
-            routing_key='poem_responses',
-            body=json.dumps(response)
-        )
-
-        print(f"Generated poem for request {poem_request_id}: {poem}")
-
-        # Acknowledge the message
-        ch.basic_ack(delivery_tag=method.delivery_tag)
-    except Exception as e:
-        print(f"Error processing request {poem_request_id}: {str(e)}")
-
-        response = {
-            'id': poem_request_id,
-            'user_id': user_id,
-            'prompt': prompt,
-            'poem': None,
-            'status': 'failed',
-            'error': str(e),
-            'created_at': created_at,
-            'updated_at': datetime.now(timezone.utc).isoformat()
-        }
-
-        # Publish the error response
-        channel.basic_publish(
-            exchange='',
-            routing_key='poem_responses',
-            body=json.dumps(response)
-        )
-
-        # Negative acknowledgement
-        ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+# @sleep_and_retry
+# @limits(calls=50, period=3600)
+# def generate_poem(prompt):
+#     response = client.completions.create(
+#         model="gpt-3.5-turbo-instruct",
+#         prompt=f"Create a Chinese 绝句 (jué jù) poem based on the following prompt: {prompt}",
+#         max_tokens=100,
+#         n=1,
+#         stop=None,
+#         temperature=0.7
+#     )
+#     return response.choices[0].text.strip()
 
 
-# Set up the consumer
-channel.basic_consume(queue='poem_requests', on_message_callback=callback)
+# def callback(ch, method, properties, body):
+#     # Decode the Base64 encoded message
+#     decoded_body = base64.b64decode(body).decode('utf-8')
+#     message = json.loads(decoded_body)
 
-print('AI Service is waiting for messages. To exit press CTRL+C')
-channel.start_consuming()
+#     poem_request_id = message['id']
+#     user_id = message['user_id']
+#     prompt = message['prompt']
+#     created_at = message['created_at']
+
+#     try:
+#         poem = generate_poem(prompt)
+
+#         response = {
+#             'id': poem_request_id,
+#             'user_id': user_id,
+#             'prompt': prompt,
+#             'poem': poem,
+#             'status': 'completed',
+#             'created_at': created_at,
+#             'updated_at': datetime.now(timezone.utc).isoformat()
+#         }
+
+#         # Publish the response
+#         channel.basic_publish(
+#             exchange='',
+#             routing_key='poem_responses',
+#             body=json.dumps(response)
+#         )
+
+#         print(f"Generated poem for request {poem_request_id}: {poem}")
+
+#         # Acknowledge the message
+#         ch.basic_ack(delivery_tag=method.delivery_tag)
+#     except Exception as e:
+#         print(f"Error processing request {poem_request_id}: {str(e)}")
+
+#         response = {
+#             'id': poem_request_id,
+#             'user_id': user_id,
+#             'prompt': prompt,
+#             'poem': None,
+#             'status': 'failed',
+#             'error': str(e),
+#             'created_at': created_at,
+#             'updated_at': datetime.now(timezone.utc).isoformat()
+#         }
+
+#         # Publish the error response
+#         channel.basic_publish(
+#             exchange='',
+#             routing_key='poem_responses',
+#             body=json.dumps(response)
+#         )
+
+#         # Negative acknowledgement
+#         ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+
+
+# # Set up the consumer
+# channel.basic_consume(queue='poem_requests', on_message_callback=callback)
+
+# print('AI Service is waiting for messages. To exit press CTRL+C')
+# channel.start_consuming()

--- a/ai_service/producer.py
+++ b/ai_service/producer.py
@@ -1,0 +1,28 @@
+# Setup producer for user side
+#
+
+import pika
+import os
+
+def send_rabbit_msg(rabbit_url, input_message):
+    # Set connection parameters
+    rmq_url = os.getenv('RABBITMQ_URL')
+    connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
+    channel = connection.channel()
+
+    # Declare the queue from user to RabbitMQ
+    channel.queue_declare(queue='poem_requests')
+    # Declare the queue from RabbitMQ to user
+    channel.queue_declare(queue='poem_responses')
+
+    # Send message from user to RabbitMQ
+    channel.basic_publish(
+        exchange='', 
+        routing_key='poem_requests', 
+        body=input_message
+    )
+
+    print(f"Your prompt: {input_message}")
+
+    # Close connection for cleanliness
+    connection.close()

--- a/ai_service/producer.py
+++ b/ai_service/producer.py
@@ -4,10 +4,9 @@
 import pika
 import os
 
-def send_rabbit_msg(rabbit_url, input_message):
+def send_rabbit_msg(rabbit_url=os.getenv('RABBITMQ_URL'), input_message=""):
     # Set connection parameters
-    rmq_url = os.getenv('RABBITMQ_URL')
-    connection = pika.BlockingConnection(pika.URLParameters(rmq_url))
+    connection = pika.BlockingConnection(pika.URLParameters(rabbit_url))
     channel = connection.channel()
 
     # Declare the queue from user to RabbitMQ


### PR DESCRIPTION
## Don't Merge This Request!!! ##

@robert-cronin - This is entirely on my fork.

I've setup two distinct files that should (untested) enable the basic functionality for a producer (user >> Rabbit) and a consumer (Rabbit). Right now, functionality is enabled by running both producer and consumer scripts and then send_rabbit_msg(input_message="test message")

Useful link that contains example code to setup the user side consumption of return msgs:
https://github.com/delaneybrian/jumpstartCS-rabbitmq-python/